### PR TITLE
Fix EOFError and escaped newlines in InstaReporter

### DIFF
--- a/InstaReporter.py
+++ b/InstaReporter.py
@@ -93,7 +93,7 @@ def profile_attack(proxies):
         i = i + 1  
   
 def main():  
-    print_success("Modules loaded!\\n")  
+    print_success("Modules loaded!\n")
   
     ret = ask_question("Would you like to use a proxy? [Y/N]")  
   
@@ -103,7 +103,7 @@ def main():
         ret = ask_question("Would you like to collect your proxies from the internet? [Y/N]")  
   
         if (ret == "Y" or ret == "y"):  
-            print_status("Gathering proxy from the Internet! This may take a while.\\n")  
+            print_status("Gathering proxy from the Internet! This may take a while.\n")  
             proxies = find_proxies()  
         elif (ret == "N" or ret == "n"):  
             print_status("Please have a maximum of 50 proxies in a file!")  
@@ -113,7 +113,7 @@ def main():
             print_error("Answer not understood, exiting!")  
             exit()  
   
-        print_success(str(len(proxies)) + " Number of proxies found!\\n")  
+        print_success(str(len(proxies)) + " Number of proxies found!\n")  
     elif (ret == "N" or ret == "n"):  
         pass  
     else:  

--- a/libs/utils.py
+++ b/libs/utils.py
@@ -34,8 +34,12 @@ def ask_question(message, *argv):
     for arg in argv:  
         message = message + " " + arg  
     print(message, end="")  
-    ret = input(": ")  
-    return ret  
+    try:
+        ret = input(": ")
+        return ret
+    except EOFError:
+        print_error("No input available! Exiting.")
+        exit(0)
   
 def parse_proxy_file(fpath):  
     if (path.exists(fpath) == False):  


### PR DESCRIPTION
## Problem

The script had two runtime issues:
1. **EOFError** when running in non-interactive environments - the `ask_question()` function didn't handle missing stdin gracefully
2. **Escaped newlines** displayed literally as `\n` instead of actual newlines in console output

## Solution

- Added try/except error handling in `ask_question()` to catch EOF errors and gracefully exit with a clear error message
- Fixed all escaped newline sequences (`\\n`) to proper Python newlines (`\n`) in print statements (lines 96, 106, and 116)

## Testing

Verified the script now:
- Starts without crashing on import/initialization
- Displays the logo and status messages correctly with proper formatting
- Handles missing input gracefully without stack traces